### PR TITLE
added logic for article for classnames

### DIFF
--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -503,7 +503,11 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                 break;
             case CraftableStatus.WrongClassJob:
                 {
-                    ImGuiUtils.TextCentered($"You are not a {RecipeData.ClassJob.GetName().ToLowerInvariant()}.");
+                    var fullClassName = RecipeData.ClassJob.GetName().ToLowerInvariant();
+                    var classArticle = "a";
+                    if (fullClassName == "Alchemist" || fullClassName == "Armorer")
+                        classArticle = "an";
+                    ImGuiUtils.TextCentered($"You are not {classArticle} {fullClassName}.");
                     var gearsetId = GetGearsetForJob(RecipeData.ClassJob);
                     if (gearsetId.HasValue)
                     {


### PR DESCRIPTION
This just adds logic that I think will work to correctly use "an" in front of "Armorer" and "Alchemist" in the recipe note window. I'll be honest, I'm not a programmer and I haven't tested this but I think it should be something along these lines. Just a tiny thing!