### PR TITLE
Use more accurate `ReciprocalSqrt` when available

### DIFF
--- a/Solver/Intrinsics.cs
+++ b/Solver/Intrinsics.cs
@@ -114,9 +114,11 @@ internal static class Intrinsics
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector256<float> ReciprocalSqrt(Vector256<float> data)
     {
+#if !IS_DETERMINISTIC
         // Accurate to 14 bits
         if (Avx512F.VL.IsSupported)
             return Avx512F.VL.ReciprocalSqrt14(data);
+#endif
 
         // Accurate to 12 bits
         if (Avx.IsSupported)

--- a/Solver/Intrinsics.cs
+++ b/Solver/Intrinsics.cs
@@ -114,6 +114,11 @@ internal static class Intrinsics
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector256<float> ReciprocalSqrt(Vector256<float> data)
     {
+        // Accurate to 14 bits
+        if (Avx512F.VL.IsSupported)
+            return Avx512F.VL.ReciprocalSqrt14(data);
+
+        // Accurate to 12 bits
         if (Avx.IsSupported)
             return Avx.ReciprocalSqrt(data);
 


### PR DESCRIPTION
Utilizes the AVX512 variant of `ReciprocalSqrt`([vrsqrt14ps](https://www.felixcloutier.com/x86/vrsqrt14ps)) that is accurate up to 14 bits of precision(rather than 12) when the host supports it.
