### PR TITLE
Strip soft hyphens and resolve names via SeStringEvaluator

### DIFF
--- a/Craftimizer/LuminaSheets.cs
+++ b/Craftimizer/LuminaSheets.cs
@@ -16,13 +16,11 @@ public static class LuminaSheets
     public static readonly ExcelSheet<ClassJob> ClassJobSheet = Module.GetSheet<ClassJob>();
     public static readonly ExcelSheet<Item> ItemSheet = Module.GetSheet<Item>();
     public static readonly ExcelSheet<Item> ItemSheetEnglish = Module.GetSheet<Item>(Language.English)!;
-    public static readonly ExcelSheet<ENpcResident> ENpcResidentSheet = Module.GetSheet<ENpcResident>();
     public static readonly ExcelSheet<Level> LevelSheet = Module.GetSheet<Level>();
     public static readonly ExcelSheet<Quest> QuestSheet = Module.GetSheet<Quest>();
     public static readonly ExcelSheet<Materia> MateriaSheet = Module.GetSheet<Materia>();
     public static readonly ExcelSheet<BaseParam> BaseParamSheet = Module.GetSheet<BaseParam>();
     public static readonly ExcelSheet<ItemFood> ItemFoodSheet = Module.GetSheet<ItemFood>();
-    public static readonly SubrowExcelSheet<SatisfactionSupply> SatisfactionSupplySheet = Module.GetSubrowSheet<SatisfactionSupply>();
     public static readonly ExcelSheet<WKSMissionToDoEvalutionRefin> WKSMissionToDoEvalutionRefinSheet = Module.GetSheet<WKSMissionToDoEvalutionRefin>();
     public static readonly ExcelSheet<RecipeLevelTable> RecipeLevelTableSheet = Module.GetSheet<RecipeLevelTable>();
     public static readonly ExcelSheet<GathererCrafterLvAdjustTable> GathererCrafterLvAdjustTableSheet = Module.GetSheet<GathererCrafterLvAdjustTable>();

--- a/Craftimizer/Service.cs
+++ b/Craftimizer/Service.cs
@@ -9,6 +9,8 @@ using Dalamud.Storage.Assets;
 
 namespace Craftimizer.Plugin;
 
+#pragma warning disable SeStringEvaluator
+
 public sealed class Service
 {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -27,6 +29,7 @@ public sealed class Service
     [PluginService] public static IPluginLog PluginLog { get; private set; }
     [PluginService] public static IGameInteropProvider GameInteropProvider { get; private set; }
     [PluginService] public static INotificationManager NotificationManager { get; private set; }
+    [PluginService] public static ISeStringEvaluator SeStringEvaluator { get; private set; }
 
     public static Plugin Plugin { get; private set; }
     public static Configuration Configuration => Plugin.Configuration;

--- a/Craftimizer/SimulatorUtils.cs
+++ b/Craftimizer/SimulatorUtils.cs
@@ -14,7 +14,7 @@ using Craftimizer.Utils;
 using Lumina.Text.ReadOnly;
 using Lumina.Text.Payloads;
 using Lumina.Excel.Sheets;
-using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using Dalamud.Utility;
 
 namespace Craftimizer.Plugin;
 
@@ -162,7 +162,7 @@ internal static class ClassJobUtils
     public static string GetName(this ClassJob me)
     {
         var job = LuminaSheets.ClassJobSheet.GetRow(me.GetClassJobIndex());
-        return job.Name.ExtractText().ToLowerInvariant();
+        return job.Name.ExtractCleanText();
     }
 
     public static string GetNameArticle(this ClassJob me)

--- a/Craftimizer/Utils/ReadOnlySeStringExtensions.cs
+++ b/Craftimizer/Utils/ReadOnlySeStringExtensions.cs
@@ -1,0 +1,12 @@
+using Dalamud.Utility;
+using Lumina.Text.ReadOnly;
+
+namespace Craftimizer.Utils;
+
+public static class ReadOnlySeStringExtensions
+{
+    public static string ExtractCleanText(this ReadOnlySeString self)
+    {
+        return self.ExtractText().StripSoftHyphen();
+    }
+}

--- a/Craftimizer/Windows/MacroEditor.cs
+++ b/Craftimizer/Windows/MacroEditor.cs
@@ -572,7 +572,7 @@ public sealed class MacroEditor : Window, IDisposable
         if (input.ItemId == 0)
             return "None";
 
-        var name = LuminaSheets.ItemSheet.GetRowOrDefault(input.ItemId)?.Name.ExtractText() ?? $"Unknown ({input.ItemId})";
+        var name = LuminaSheets.ItemSheet.GetRowOrDefault(input.ItemId)?.Name.ExtractCleanText() ?? $"Unknown ({input.ItemId})";
         return input.IsHQ ? $"{name} (HQ)" : name;
     }
 
@@ -778,11 +778,11 @@ public sealed class MacroEditor : Window, IDisposable
                 searchableRecipes,
                 fontHandle,
                 ImGui.GetContentRegionAvail().X - rightSideWidth,
-                r => r.Recipe.ItemResult.Value.Name.ExtractText(),
+                r => r.Recipe.ItemResult.Value.Name.ExtractCleanText(),
                 r => r.Recipe.RowId.ToString(),
                 r =>
                 {
-                    ImGui.TextUnformatted($"{r.Recipe.ItemResult.Value.Name.ExtractText()}");
+                    ImGui.TextUnformatted($"{r.Recipe.ItemResult.Value.Name.ExtractCleanText()}");
 
                     var classJob = (ClassJob)r.Recipe.CraftType.RowId;
                     var textLevel = SqText.LevelPrefix.ToIconChar() + SqText.ToLevelString(r.Recipe.RecipeLevelTable.Value!.ClassJobLevel);
@@ -964,10 +964,10 @@ public sealed class MacroEditor : Window, IDisposable
             {
                 var perItem = RecipeData.CalculateItemStartingQuality(idx, 1);
                 var total = RecipeData.CalculateItemStartingQuality(idx, hqCount);
-                ImGuiUtils.Tooltip($"{ingredient.Item.Name.ExtractText()} {SeIconChar.HighQuality.ToIconString()}\n+{perItem} Quality/Item{(total > 0 ? $"\n+{total} Quality" : "")}");
+                ImGuiUtils.Tooltip($"{ingredient.Item.Name.ExtractCleanText()} {SeIconChar.HighQuality.ToIconString()}\n+{perItem} Quality/Item{(total > 0 ? $"\n+{total} Quality" : "")}");
             }
             else if (ingredient.Amount != 0)
-                ImGuiUtils.Tooltip($"{ingredient.Item.Name.ExtractText()}");
+                ImGuiUtils.Tooltip($"{ingredient.Item.Name.ExtractCleanText()}");
         }
         ImGui.SameLine(0, 5);
         ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - (5 + ImGui.CalcTextSize("/").X + 5 + ImGui.CalcTextSize($"99").X));
@@ -1240,7 +1240,7 @@ public sealed class MacroEditor : Window, IDisposable
                         {
                             var status = effect.Status();
                             using var _reset = ImRaii.DefaultFont();
-                            ImGuiUtils.Tooltip($"{status.Name.ExtractText()}\n{status.Description.ExtractText()}");
+                            ImGuiUtils.Tooltip($"{status.Name.ExtractCleanText()}\n{status.Description.ExtractCleanText()}");
                         }
                         ImGui.SameLine();
                     }

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -1159,7 +1159,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
     private static (string NpcName, string Territory, Vector2 MapLocation, MapLinkPayload Payload) ResolveLevelData(uint levelRowId)
     {
         var level = LuminaSheets.LevelSheet.GetRow(levelRowId);
-        var placeName = ResolvePlaceName(level.Territory.Value.PlaceName.RowId);
+        var placeName = level.Territory.Value.PlaceName.Value.Name.ExtractCleanText();
         var location = WorldToMap2(new(level.X, level.Z), level.Map.Value!);
 
         return (ResolveNpcResidentName(level.Object.RowId), placeName, location, new(level.Territory.RowId, level.Map.RowId, location.X, location.Y));
@@ -1173,11 +1173,6 @@ public sealed unsafe class RecipeNote : Window, IDisposable
     private static string ResolveNpcResidentName(uint npcRowId)
     {
         return Service.SeStringEvaluator.EvaluateObjStr(ObjectKind.EventNpc, npcRowId);
-    }
-
-    private static string ResolvePlaceName(uint placeNameId)
-    {
-        return Service.SeStringEvaluator.EvaluateFromAddon(1337, [placeNameId]).ExtractText().StripSoftHyphen();
     }
 
     private static string GetCoordinatesString(Vector2 pos)

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -3,6 +3,7 @@ using Craftimizer.Simulator;
 using Craftimizer.Simulator.Actions;
 using Craftimizer.Solver;
 using Craftimizer.Utils;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
@@ -17,12 +18,12 @@ using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -589,7 +590,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                     if (ImGui.IsItemHovered())
                         ImGuiUtils.Tooltip("Open in map");
 
-                    ImGuiUtils.TextCentered($"{questTerritory} ({questLocation.X:0.0}, {questLocation.Y:0.0})");
+                    ImGuiUtils.TextCentered($"{questTerritory} ({GetCoordinatesString(questLocation)})");
                 }
                 break;
             case CraftableStatus.WrongClassJob:
@@ -624,7 +625,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                     if (ImGui.IsItemHovered())
                         ImGuiUtils.Tooltip("Open in map");
 
-                    ImGuiUtils.TextCentered($"{vendorTerritory} ({vendorLoation.X:0.0}, {vendorLoation.Y:0.0})");
+                    ImGuiUtils.TextCentered($"{vendorTerritory} ({GetCoordinatesString(vendorLoation)})");
                 }
                 break;
             case CraftableStatus.RequiredItem:
@@ -1158,10 +1159,10 @@ public sealed unsafe class RecipeNote : Window, IDisposable
     private static (string NpcName, string Territory, Vector2 MapLocation, MapLinkPayload Payload) ResolveLevelData(uint levelRowId)
     {
         var level = LuminaSheets.LevelSheet.GetRow(levelRowId);
-        var territory = level.Territory.Value.PlaceName.Value.Name.ExtractCleanText();
+        var placeName = ResolvePlaceName(level.Territory.Value.PlaceName.RowId);
         var location = WorldToMap2(new(level.X, level.Z), level.Map.Value!);
 
-        return (ResolveNpcResidentName(level.Object.RowId), territory, location, new(level.Territory.RowId, level.Map.RowId, location.X, location.Y));
+        return (ResolveNpcResidentName(level.Object.RowId), placeName, location, new(level.Territory.RowId, level.Map.RowId, location.X, location.Y));
     }
 
     private static Vector2 WorldToMap2(Vector2 worldCoordinates, Lumina.Excel.Sheets.Map map)
@@ -1171,8 +1172,17 @@ public sealed unsafe class RecipeNote : Window, IDisposable
 
     private static string ResolveNpcResidentName(uint npcRowId)
     {
-        var resident = LuminaSheets.ENpcResidentSheet.GetRow(npcRowId);
-        return resident.Singular.ExtractText();
+        return Service.SeStringEvaluator.EvaluateObjStr(ObjectKind.EventNpc, npcRowId);
+    }
+
+    private static string ResolvePlaceName(uint placeNameId)
+    {
+        return Service.SeStringEvaluator.EvaluateFromAddon(1337, [placeNameId]).ExtractText().StripSoftHyphen();
+    }
+
+    private static string GetCoordinatesString(Vector2 pos)
+    {
+        return $"{pos.X.ToString("0.0", CultureInfo.InvariantCulture)}, {pos.Y.ToString("0.0", CultureInfo.InvariantCulture)}";
     }
 
     private static int? GetGearsetForJob(ClassJob job)

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -630,7 +630,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             case CraftableStatus.RequiredItem:
                 {
                     var item = RecipeData.Recipe.ItemRequired.Value!;
-                    var itemName = item.Name.ExtractText();
+                    var itemName = item.Name.ExtractCleanText();
                     var imageSize = ImGui.GetFrameHeight();
 
                     ImGuiUtils.TextCentered($"You are missing the required equipment.");
@@ -644,7 +644,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             case CraftableStatus.RequiredStatus:
                 {
                     var status = RecipeData.Recipe.StatusRequired.Value!;
-                    var statusName = status.Name.ExtractText();
+                    var statusName = status.Name.ExtractCleanText();
                     var statusIcon = Service.IconManager.GetIconCached(status.Icon);
                     var imageSize = new Vector2(ImGui.GetFrameHeight() * (statusIcon.AspectRatio ?? 1), ImGui.GetFrameHeight());
 
@@ -1158,7 +1158,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
     private static (string NpcName, string Territory, Vector2 MapLocation, MapLinkPayload Payload) ResolveLevelData(uint levelRowId)
     {
         var level = LuminaSheets.LevelSheet.GetRow(levelRowId);
-        var territory = level.Territory.Value.PlaceName.Value.Name.ExtractText();
+        var territory = level.Territory.Value.PlaceName.Value.Name.ExtractCleanText();
         var location = WorldToMap2(new(level.X, level.Z), level.Map.Value!);
 
         return (ResolveNpcResidentName(level.Object.RowId), territory, location, new(level.Territory.RowId, level.Map.RowId, location.X, location.Y));

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -392,7 +392,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
                 {
                     var status = effect.Status();
                     using var _reset = ImRaii.DefaultFont();
-                    ImGuiUtils.Tooltip($"{status.Name.ExtractText()}\n{status.Description.ExtractText()}");
+                    ImGuiUtils.Tooltip($"{status.Name.ExtractCleanText()}\n{status.Description.ExtractCleanText()}");
                 }
                 ImGui.SameLine();
             }


### PR DESCRIPTION
Hey there,
I installed your plugin (yay, crafting!) and saw soft hyphens in German item names (shocking!).
So I present you a PR to fix this situation.

Before:
![Before](https://github.com/user-attachments/assets/35995cdc-2d63-44c4-99e8-2e389cc3c7af)

After:
![After](https://github.com/user-attachments/assets/d6e7a9a2-2353-4cdd-9ffb-dd04cc01a2d1)

I also stripped them from Status names/descriptions.

Additionally, I've allowed myself to add resolving of ENpcResident names and PlaceNames via the new experimental SeStringEvaluator. Not that it was needed in your case (I don't think any of these use noun placeholders), but I thought why not.

Just as a little hint though, this doesn't fit at all:
![Oops, no space](https://github.com/user-attachments/assets/c489ed15-1cf3-4496-afa2-caf170ce4908)
I did not fix that, but I changed the code to format coordinates to use InvariantCulture, because in German (yes, yes) we use `,` as decimal separator and it should be `.` for coordinates. And the jobs name first letter should be capitalized in German, so I removed the `ToLowerInvariant()`. 👀

I hope the changes aren't too annoying and will see ya on Discord (probably).
\- Hasel 🙂