### PR TITLE
Update to API13

### DIFF
--- a/Craftimizer/Craftimizer.csproj
+++ b/Craftimizer/Craftimizer.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/12.0.2">
+<Project Sdk="Dalamud.NET.Sdk/13.0.0">
   <PropertyGroup>
     <Authors>Asriel Camora</Authors>
-    <Version>2.7.2.1</Version>
+    <Version>2.7.2.2</Version>
     <PackageProjectUrl>https://github.com/WorkingRobot/Craftimizer.git</PackageProjectUrl>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/Craftimizer/ImGuiExtras.cs
+++ b/Craftimizer/ImGuiExtras.cs
@@ -202,17 +202,19 @@ internal static unsafe class ImGuiExtras
         }
         GetUtf8(text, utf8TextBytes, utf8TextByteCount);
 
-        var ret = ImGuiNative.ImFont_CalcWordWrapPositionA(font.NativePtr, scale, utf8TextBytes, utf8TextBytes + utf8TextByteCount, wrap_width);
+        var textSpan = new ReadOnlySpan<byte>(utf8TextBytes, utf8TextByteCount);
+
+        var ret = font.CalcWordWrapPositionA(scale, textSpan, wrap_width);
 
         int? retVal = null;
-        if (utf8TextBytes <= ret && ret <= utf8TextBytes + utf8TextByteCount)
+
+        if (ret > 0 && ret <= utf8TextByteCount)
         {
-            var retIndex = (int)(ret - utf8TextBytes);
-            retVal = Encoding.UTF8.GetCharCount(utf8TextBytes, retIndex);
+            retVal = Encoding.UTF8.GetCharCount(utf8TextBytes, ret);
         }
 
         if (utf8TextByteCount > StackAllocationSizeLimit)
-            Free(utf8TextBytes);
+                Free(utf8TextBytes);
 
         return retVal;
     }

--- a/Craftimizer/ImGuiExtras.cs
+++ b/Craftimizer/ImGuiExtras.cs
@@ -179,7 +179,7 @@ internal static unsafe class ImGuiExtras
         igRenderFrame(p_min, p_max, fill_col, border, rounding);
 
     public static unsafe void RenderRectFilledRangeH(ImDrawListPtr draw_list, Vector4 rect, uint col, float x_start_norm, float x_end_norm, float rounding) =>
-        igRenderRectFilledRangeH(draw_list.NativePtr, &rect, col, x_start_norm, x_end_norm, rounding);
+        igRenderRectFilledRangeH(draw_list, &rect, col, x_start_norm, x_end_norm, rounding);
 
     public static unsafe bool ItemSize(Vector2 size, float text_baseline_y = -1.0f) =>
         igItemSize_Vec2(size, text_baseline_y);

--- a/Craftimizer/ImGuiExtras.cs
+++ b/Craftimizer/ImGuiExtras.cs
@@ -1,4 +1,4 @@
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -3,7 +3,7 @@ using Dalamud.Interface;
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using ImPlotNET;
 using MathNet.Numerics.Statistics;
 using System;

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -659,7 +659,8 @@ internal static class ImGuiUtils
             currentWrapWidth = wrapPosX - currentPos;
 
         var textBuf = text.AsSpan();
-        var lineSize = font.CalcWordWrapPositionA(ImGuiHelpers.GlobalScale, textBuf, currentWrapWidth) ?? textBuf.Length;
+        var wrapIndex = font.CalcWordWrapPositionA(ImGuiHelpers.GlobalScale, textBuf, currentWrapWidth);
+        var lineSize = wrapIndex == 0 ? textBuf.Length : wrapIndex;
         var lineBuf = textBuf[..lineSize];
         ImGui.TextUnformatted(lineBuf.ToString());
         var remainingBuf = textBuf[lineSize..].TrimStart();

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -4,7 +4,7 @@ using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
-using ImPlotNET;
+using Dalamud.Bindings.ImPlot;
 using MathNet.Numerics.Statistics;
 using System;
 using System.Collections.Generic;

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -322,7 +322,7 @@ internal static class ImGuiUtils
         using var plot = ImRaii2.Plot("##violin", size, ImPlotFlags.CanvasOnly | ImPlotFlags.NoInputs | ImPlotFlags.NoChild | ImPlotFlags.NoFrame);
         if (plot)
         {
-            ImPlot.SetupAxes(null, null, ImPlotAxisFlags.NoDecorations, ImPlotAxisFlags.NoDecorations | ImPlotAxisFlags.AutoFit);
+            ImPlot.SetupAxes([], [], ImPlotAxisFlags.NoDecorations, ImPlotAxisFlags.NoDecorations | ImPlotAxisFlags.AutoFit);
             ImPlot.SetupAxisLimits(ImAxis.X1, data.Min, data.Max, ImPlotCond.Always);
             ImPlot.SetupFinish();
 
@@ -333,7 +333,7 @@ internal static class ImGuiUtils
                     var label_id = stackalloc byte[] { (byte)'\0' };
                     fixed (ViolinData.Point* p = points)
                     {
-                        ImPlotNative.ImPlot_PlotShaded_FloatPtrFloatPtrFloatPtr(label_id, &p->X, &p->Y, &p->Y2, points.Length, ImPlotShadedFlags.None, 0, sizeof(ViolinData.Point));
+                        ImPlot.PlotShaded(label_id, &p->X, &p->Y, &p->Y2, points.Length, ImPlotShadedFlags.None, 0, sizeof(ViolinData.Point));
                     }
                 }
             }

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -315,8 +315,8 @@ internal static class ImGuiUtils
 
     public static void ViolinPlot(in ViolinData data, Vector2 size)
     {
-        using var padding = ImRaii2.PushStyle(ImPlotStyleVar.PlotPadding, Vector2.Zero);
-        using var plotBg = ImRaii2.PushColor(ImPlotCol.PlotBg, Vector4.Zero);
+        using var padding = ImRaii2.PushStyle(ImPlotStyleVar.Padding, Vector2.Zero);
+        using var plotBg = ImRaii2.PushColor(ImPlotCol.Bg, Vector4.Zero);
         using var fill = ImRaii2.PushColor(ImPlotCol.Fill, Vector4.One.WithAlpha(.5f));
 
         using var plot = ImRaii2.Plot("##violin", size, ImPlotFlags.CanvasOnly | ImPlotFlags.NoInputs | ImPlotFlags.NoChild | ImPlotFlags.NoFrame);

--- a/Craftimizer/ImGuiUtils.cs
+++ b/Craftimizer/ImGuiUtils.cs
@@ -522,18 +522,15 @@ internal static class ImGuiUtils
         ImGuiListClipperPtr imGuiListClipperPtr;
         unsafe
         {
-            imGuiListClipperPtr = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper_ImGuiListClipper());
+            imGuiListClipperPtr = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper());
         }
         try
         {
             imGuiListClipperPtr.Begin(data.Count, lineHeight);
             while (imGuiListClipperPtr.Step())
             {
-                for (var i = imGuiListClipperPtr.DisplayStart; i <= imGuiListClipperPtr.DisplayEnd; i++)
+                for (var i = imGuiListClipperPtr.DisplayStart; i < imGuiListClipperPtr.DisplayEnd; i++)
                 {
-                    if (i >= data.Count)
-                        return false;
-
                     if (i >= 0)
                     {
                         if (func(data[i]))

--- a/Craftimizer/ImRaii2.cs
+++ b/Craftimizer/ImRaii2.cs
@@ -1,6 +1,6 @@
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Bindings.ImGui;
-using ImPlotNET;
+using Dalamud.Bindings.ImPlot;
 using System;
 using System.Numerics;
 

--- a/Craftimizer/ImRaii2.cs
+++ b/Craftimizer/ImRaii2.cs
@@ -1,5 +1,5 @@
 using Dalamud.Interface.Utility.Raii;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using ImPlotNET;
 using System;
 using System.Numerics;

--- a/Craftimizer/Utils/Colors.cs
+++ b/Craftimizer/Utils/Colors.cs
@@ -1,6 +1,6 @@
 using Craftimizer.Plugin;
 using Dalamud.Interface.Colors;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Numerics;
 

--- a/Craftimizer/Utils/DynamicBars.cs
+++ b/Craftimizer/Utils/DynamicBars.cs
@@ -1,6 +1,6 @@
 using Craftimizer.Plugin;
 using Dalamud.Interface.Utility.Raii;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System.Collections.Generic;
 using System;
 using System.Numerics;

--- a/Craftimizer/Utils/IconManager.cs
+++ b/Craftimizer/Utils/IconManager.cs
@@ -1,6 +1,7 @@
 using Craftimizer.Plugin;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Utility;
 using System;
 using System.Collections.Generic;
@@ -19,7 +20,7 @@ public interface ITextureIcon
 
     float? AspectRatio => Dimensions is { } d ? d.X / d.Y : null;
 
-    nint ImGuiHandle { get; }
+    ImTextureID Handle { get; }
 }
 
 public interface ILoadedTextureIcon : ITextureIcon, IDisposable { }
@@ -32,7 +33,7 @@ public sealed class IconManager : IDisposable
 
         public Vector2? Dimensions => GetWrap()?.Size;
 
-        public nint ImGuiHandle => GetWrapOrEmpty().ImGuiHandle;
+        public ImTextureID Handle => GetWrapOrEmpty().Handle;
 
         private Task<IDalamudTextureWrap> TextureWrapTask { get; }
         private CancellationTokenSource DisposeToken { get; }
@@ -69,7 +70,7 @@ public sealed class IconManager : IDisposable
 
         public Vector2? Dimensions => Base.Dimensions;
 
-        public nint ImGuiHandle => Base.ImGuiHandle;
+        public ImTextureID Handle => Base.Handle;
 
         public void Release()
         {

--- a/Craftimizer/Utils/MacroCopy.cs
+++ b/Craftimizer/Utils/MacroCopy.cs
@@ -5,7 +5,7 @@ using Dalamud.Interface.ImGuiNotification;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 

--- a/Craftimizer/Utils/RecipeData.cs
+++ b/Craftimizer/Utils/RecipeData.cs
@@ -34,10 +34,10 @@ public sealed record RecipeData
         ClassJob = (ClassJob)Recipe.CraftType.RowId;
 
         var resolvedLevelTableRow = Recipe.RecipeLevelTable.RowId;
-        if (Recipe.Unknown0 != 0)
+        if (Recipe.MaxAdjustableJobLevel.RowId != 0)
         {
-            AdjustedJobLevel = Math.Min(explicitlyAdjustedJobLevel ?? ClassJob.GetWKSSyncedLevel(), Recipe.Unknown0);
-            resolvedLevelTableRow = LuminaSheets.GathererCrafterLvAdjustTableSheet.GetRow(AdjustedJobLevel.Value).Unknown0;
+            AdjustedJobLevel = Math.Min(explicitlyAdjustedJobLevel ?? ClassJob.GetWKSSyncedLevel(), (ushort)Recipe.MaxAdjustableJobLevel.RowId);
+            resolvedLevelTableRow = LuminaSheets.GathererCrafterLvAdjustTableSheet.GetRow(AdjustedJobLevel.Value).RecipeLevel.RowId;
         }
         Table = LuminaSheets.RecipeLevelTableSheet.GetRow(resolvedLevelTableRow);
 
@@ -46,7 +46,7 @@ public sealed record RecipeData
             IsExpert = Recipe.IsExpert,
             ClassJobLevel = Table.ClassJobLevel,
             ConditionsFlag = Table.ConditionsFlag,
-            MaxDurability = (Recipe.Unknown0 != 0 ? 80 : Table.Durability) * Recipe.DurabilityFactor / 100,
+            MaxDurability = (Recipe.MaxAdjustableJobLevel.RowId != 0 ? 80 : Table.Durability) * Recipe.DurabilityFactor / 100,
             MaxQuality = (Recipe.CanHq || Recipe.IsExpert) ? (int)Table.Quality * Recipe.QualityFactor / 100 : 0,
             MaxProgress = Table.Difficulty * Recipe.DifficultyFactor / 100,
             QualityModifier = Table.QualityModifier,

--- a/Craftimizer/Windows/MacroClipboard.cs
+++ b/Craftimizer/Windows/MacroClipboard.cs
@@ -2,7 +2,7 @@ using Craftimizer.Plugin;
 using Dalamud.Interface;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/Craftimizer/Windows/MacroClipboard.cs
+++ b/Craftimizer/Windows/MacroClipboard.cs
@@ -17,9 +17,11 @@ public sealed class MacroClipboard : Window, IDisposable
 
     private List<string> Macros { get; }
 
+    private readonly byte[] macroBuffer = [];
+
     public MacroClipboard(IEnumerable<string> macros) : base("Macro Clipboard", WindowFlags)
     {
-        Macros = new(macros);
+        Macros = [.. macros];
 
         IsOpen = true;
         AllowPinning = false;
@@ -77,7 +79,7 @@ public sealed class MacroClipboard : Window, IDisposable
             using var padding = ImRaii.PushStyle(ImGuiStyleVar.FramePadding, Vector2.Zero);
             using var bg = ImRaii.PushColor(ImGuiCol.FrameBg, Vector4.Zero);
             var lineCount = macro.Count(c => c == '\n') + 1;
-            ImGui.InputTextMultiline("", ref macro, (uint)macro.Length + 1, new(availWidth, ImGui.GetTextLineHeight() * Math.Max(15, lineCount) + ImGui.GetStyle().FramePadding.Y), ImGuiInputTextFlags.ReadOnly | ImGuiInputTextFlags.AutoSelectAll);
+            ImGui.InputTextMultiline("", macro, new(availWidth, ImGui.GetTextLineHeight() * Math.Max(15, lineCount) + ImGui.GetStyle().FramePadding.Y), ImGuiInputTextFlags.ReadOnly | ImGuiInputTextFlags.AutoSelectAll);
         }
 
         if (buttonHovered)

--- a/Craftimizer/Windows/MacroClipboard.cs
+++ b/Craftimizer/Windows/MacroClipboard.cs
@@ -17,7 +17,7 @@ public sealed class MacroClipboard : Window, IDisposable
 
     private List<string> Macros { get; }
 
-    private readonly byte[] macroBuffer = [];
+    private byte[] macroBuffer = [];
 
     public MacroClipboard(IEnumerable<string> macros) : base("Macro Clipboard", WindowFlags)
     {
@@ -79,7 +79,15 @@ public sealed class MacroClipboard : Window, IDisposable
             using var padding = ImRaii.PushStyle(ImGuiStyleVar.FramePadding, Vector2.Zero);
             using var bg = ImRaii.PushColor(ImGuiCol.FrameBg, Vector4.Zero);
             var lineCount = macro.Count(c => c == '\n') + 1;
-            ImGui.InputTextMultiline("", macro, new(availWidth, ImGui.GetTextLineHeight() * Math.Max(15, lineCount) + ImGui.GetStyle().FramePadding.Y), ImGuiInputTextFlags.ReadOnly | ImGuiInputTextFlags.AutoSelectAll);
+
+            const int bufferSize = 1024;
+            if (macroBuffer.Length < bufferSize)
+                macroBuffer = new byte[bufferSize];
+
+            System.Text.Encoding.UTF8.GetBytes(macro + "\0", macroBuffer);
+
+            var size = new Vector2(availWidth, ImGui.GetTextLineHeight() * Math.Max(15, lineCount) + ImGui.GetStyle().FramePadding.Y);
+            ImGui.InputTextMultiline("", macroBuffer, new(availWidth, ImGui.GetTextLineHeight() * Math.Max(15, lineCount) + ImGui.GetStyle().FramePadding.Y), ImGuiInputTextFlags.ReadOnly | ImGuiInputTextFlags.AutoSelectAll);
         }
 
         if (buttonHovered)

--- a/Craftimizer/Windows/MacroEditor.cs
+++ b/Craftimizer/Windows/MacroEditor.cs
@@ -25,6 +25,7 @@ using SimNoRandom = Craftimizer.Simulator.SimulatorNoRandom;
 using Recipe = Lumina.Excel.Sheets.Recipe;
 using Dalamud.Utility;
 using Craftimizer.Solver;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Craftimizer.Windows;
 
@@ -719,6 +720,18 @@ public sealed class MacroEditor : Window, IDisposable
 
         public bool Equals(RecipeWrapper other) =>
             Recipe.RowId == other.Recipe.RowId;
+
+        public override int GetHashCode() =>
+            Recipe.RowId.GetHashCode();
+
+        public override bool Equals(object? obj) =>
+            obj is RecipeWrapper other && Equals(other);
+
+        public static bool operator ==(RecipeWrapper left, RecipeWrapper right) =>
+            left.Equals(right);
+
+        public static bool operator !=(RecipeWrapper left, RecipeWrapper right) =>
+            !left.Equals(right);
     }
 
     private readonly List<RecipeWrapper> searchableRecipes = LuminaSheets.RecipeSheet.Where(r => r.RecipeLevelTable.RowId != 0 && r.ItemResult.RowId != 0).Select(r => new RecipeWrapper(r)).ToList();

--- a/Craftimizer/Windows/MacroEditor.cs
+++ b/Craftimizer/Windows/MacroEditor.cs
@@ -270,7 +270,7 @@ public sealed class MacroEditor : Window, IDisposable
         uv0 /= new Vector2(56);
         uv1 /= new Vector2(56);
 
-        ImGui.Image(Service.IconManager.GetIconCached(RecipeData.ClassJob.GetIconId()).ImGuiHandle, new Vector2(imageSize), uv0, uv1);
+        ImGui.Image(Service.IconManager.GetIconCached(RecipeData.ClassJob.GetIconId()).Handle, new Vector2(imageSize), uv0, uv1);
         ImGui.SameLine(0, 5);
         AxisFont.Text(textClassName);
 
@@ -346,7 +346,7 @@ public sealed class MacroEditor : Window, IDisposable
                     {
                         var v = CharacterStats.HasSplendorousBuff;
                         var tint = v ? Vector4.One : disabledTint;
-                        if (ImGui.ImageButton(SplendorousBadge.ImGuiHandle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
+                        if (ImGui.ImageButton(SplendorousBadge.Handle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
                             CharacterStats = CharacterStats with { HasSplendorousBuff = !v };
                     }
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
@@ -364,7 +364,7 @@ public sealed class MacroEditor : Window, IDisposable
                     using (var d = ImRaii.Disabled(specialistLevel > CharacterStats.Level))
                     {
                         var tint = new Vector4(0.99f, 0.97f, 0.62f, 1f) * (v ? Vector4.One : disabledTint);
-                        if (ImGui.ImageButton(SpecialistBadge.ImGuiHandle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
+                        if (ImGui.ImageButton(SpecialistBadge.Handle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
                         {
                             v = !v;
                             newIsSpecialist = v;
@@ -380,7 +380,7 @@ public sealed class MacroEditor : Window, IDisposable
                     {
                         var v = CharacterStats.CanUseManipulation && manipLevel <= CharacterStats.Level;
                         var tint = (v || manipLevel > CharacterStats.Level) ? disabledTint : Vector4.One;
-                        if (ImGui.ImageButton((v ? ManipulationBadge : NoManipulationBadge).ImGuiHandle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
+                        if (ImGui.ImageButton((v ? ManipulationBadge : NoManipulationBadge).Handle, new Vector2(imageButtonSize), default, Vector2.One, imageButtonPadding, default, tint))
                             CharacterStats = CharacterStats with { CanUseManipulation = !v };
                     }
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
@@ -392,7 +392,7 @@ public sealed class MacroEditor : Window, IDisposable
                 var buffBadgeSize = new Vector2(imageSize * (WellFedBadge.AspectRatio ?? 1), imageSize);
 
                 (uint ItemId, bool HQ)? newFoodBuff = null;
-                ImGui.Image(WellFedBadge.ImGuiHandle, buffBadgeSize);
+                ImGui.Image(WellFedBadge.Handle, buffBadgeSize);
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip("Food");
                 ImGui.SameLine(0, 5);
@@ -427,7 +427,7 @@ public sealed class MacroEditor : Window, IDisposable
                 }
 
                 (uint ItemId, bool HQ)? newMedicineBuff = null;
-                ImGui.Image(MedicatedBadge.ImGuiHandle, buffBadgeSize);
+                ImGui.Image(MedicatedBadge.Handle, buffBadgeSize);
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip("Medicine");
                 ImGui.SameLine(0, 5);
@@ -464,7 +464,7 @@ public sealed class MacroEditor : Window, IDisposable
                 ImGui.TableNextColumn();
 
                 int? newFCCraftsmanshipBuff = null;
-                ImGui.Image(EatFromTheHandBadge.ImGuiHandle, buffBadgeSize);
+                ImGui.Image(EatFromTheHandBadge.Handle, buffBadgeSize);
                 var fcBuffName = "Eat from the Hand";
                 var fcStatName = "Craftsmanship";
                 if (ImGui.IsItemHovered())
@@ -491,7 +491,7 @@ public sealed class MacroEditor : Window, IDisposable
                 }
 
                 int? newFCControlBuff = null;
-                ImGui.Image(InControlBadge.ImGuiHandle, buffBadgeSize);
+                ImGui.Image(InControlBadge.Handle, buffBadgeSize);
                 fcBuffName = "In Control";
                 fcStatName = "Control";
                 if (ImGui.IsItemHovered())
@@ -763,7 +763,7 @@ public sealed class MacroEditor : Window, IDisposable
             (isExpert ? badgeSize.X + 3 : 0);
         ImGui.AlignTextToFramePadding();
 
-        ImGui.Image(Service.IconManager.GetIconCached(RecipeData.Recipe.ItemResult.Value.Icon).ImGuiHandle, new Vector2(imageSize));
+        ImGui.Image(Service.IconManager.GetIconCached(RecipeData.Recipe.ItemResult.Value.Icon).Handle, new Vector2(imageSize));
 
         ImGui.SameLine(0, 5);
 
@@ -801,7 +801,7 @@ public sealed class MacroEditor : Window, IDisposable
                     uv1 /= new Vector2(56);
 
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetStyle().FramePadding.Y / 2);
-                    ImGui.Image(Service.IconManager.GetIconCached(classJob.GetIconId()).ImGuiHandle, new Vector2(imageSize), uv0, uv1);
+                    ImGui.Image(Service.IconManager.GetIconCached(classJob.GetIconId()).Handle, new Vector2(imageSize), uv0, uv1);
                     ImGui.SameLine(0, 5);
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + (fontHandle.FontSize - textLevelSize.Y) / 2);
                     ImGui.TextUnformatted(textLevel);
@@ -837,7 +837,7 @@ public sealed class MacroEditor : Window, IDisposable
         if (isAdjustable)
         {
             ImGui.SameLine(0, 3);
-            ImGui.Image(CosmicExplorationBadge.ImGuiHandle, new(imageSize));
+            ImGui.Image(CosmicExplorationBadge.Handle, new(imageSize));
             if (ImGui.IsItemHovered())
                 ImGuiUtils.Tooltip($"Cosmic Exploration");
         }
@@ -846,7 +846,7 @@ public sealed class MacroEditor : Window, IDisposable
         {
             ImGui.SameLine(0, 3);
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + badgeOffset);
-            ImGui.Image(CollectibleBadge.ImGuiHandle, badgeSize);
+            ImGui.Image(CollectibleBadge.Handle, badgeSize);
             if (ImGui.IsItemHovered())
                 ImGuiUtils.Tooltip($"Collectible");
         }
@@ -855,7 +855,7 @@ public sealed class MacroEditor : Window, IDisposable
         {
             ImGui.SameLine(0, 3);
             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + badgeOffset);
-            ImGui.Image(ExpertBadge.ImGuiHandle, badgeSize);
+            ImGui.Image(ExpertBadge.Handle, badgeSize);
             if (ImGui.IsItemHovered())
                 ImGuiUtils.Tooltip($"Expert Recipe");
         }
@@ -957,7 +957,7 @@ public sealed class MacroEditor : Window, IDisposable
         var imageSize = ImGui.GetFrameHeight();
 
         using (var d = ImRaii.Disabled(!canHq))
-            ImGui.Image(icon.ImGuiHandle, new Vector2(imageSize));
+            ImGui.Image(icon.Handle, new Vector2(imageSize));
         if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
         {
             if (canHq)
@@ -1073,7 +1073,7 @@ public sealed class MacroEditor : Window, IDisposable
                 {
                     var actionBase = actions[i].Base();
                     var canUse = actionBase.CanUse(sim);
-                    if (ImGui.ImageButton(actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(imageSize), default, Vector2.One, 0, default, !canUse ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One) && !SolverRunning)
+                    if (ImGui.ImageButton(actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(imageSize), default, Vector2.One, 0, default, !canUse ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One) && !SolverRunning)
                         AddStep(actions[i]);
                     if (!canUse &&
                         (CharacterStats.Level < actionBase.Level ||
@@ -1097,7 +1097,7 @@ public sealed class MacroEditor : Window, IDisposable
                         if (_source)
                         {
                             ImGuiExtras.SetDragDropPayload("macroActionInsert", actions[i]);
-                            ImGui.ImageButton(actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(imageSize));
+                            ImGui.ImageButton(actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(imageSize));
                         }
                     }
                 }
@@ -1228,7 +1228,7 @@ public sealed class MacroEditor : Window, IDisposable
                             var icon = effect.GetIcon(effects.GetStrength(effect));
                             var size = new Vector2(buffIconHeight * (icon.AspectRatio ?? 1), buffIconHeight);
 
-                            ImGui.Image(icon.ImGuiHandle, size);
+                            ImGui.Image(icon.Handle, size);
                             if (!effect.IsIndefinite())
                             {
                                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() - buffDurationShift);
@@ -1302,7 +1302,7 @@ public sealed class MacroEditor : Window, IDisposable
                 var actionBase = action.Base();
                 var failedAction = response != ActionResponse.UsedAction;
                 using var id = ImRaii.PushId(i);
-                if (ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(imageSize), default, Vector2.One, 0, default, failedAction ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One) && !SolverRunning)
+                if (ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).Handle, new(imageSize), default, Vector2.One, 0, default, failedAction ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One) && !SolverRunning)
                     RemoveStep(i);
                 if (response is ActionResponse.ActionNotUnlocked ||
                     (
@@ -1331,7 +1331,7 @@ public sealed class MacroEditor : Window, IDisposable
                         if (_source)
                         {
                             ImGuiExtras.SetDragDropPayload("macroAction", i);
-                            ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(imageSize));
+                            ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).Handle, new(imageSize));
                         }
                     }
                     using (var _target = ImRaii.DragDropTarget())

--- a/Craftimizer/Windows/MacroEditor.cs
+++ b/Craftimizer/Windows/MacroEditor.cs
@@ -12,7 +12,7 @@ using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
-using ImGuDalamud.Bindings.ImGuiiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Craftimizer/Windows/MacroEditor.cs
+++ b/Craftimizer/Windows/MacroEditor.cs
@@ -12,7 +12,7 @@ using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
-using ImGuiNET;
+using ImGuDalamud.Bindings.ImGuiiNET;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Craftimizer/Windows/MacroList.cs
+++ b/Craftimizer/Windows/MacroList.cs
@@ -3,7 +3,7 @@ using Craftimizer.Utils;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface;
 using Dalamud.Interface.Windowing;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using Craftimizer.Simulator;
 using Craftimizer.Simulator.Actions;

--- a/Craftimizer/Windows/MacroList.cs
+++ b/Craftimizer/Windows/MacroList.cs
@@ -281,7 +281,7 @@ public sealed class MacroList : Window, IDisposable
                         var shouldShowMore = i + 1 == itemsPerRow * 2 && i + 1 < itemCount;
                         if (!shouldShowMore)
                         {
-                            ImGui.Image(macro.Actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(miniRowHeight));
+                            ImGui.Image(macro.Actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(miniRowHeight));
                             if (ImGui.IsItemHovered())
                                 ImGuiUtils.Tooltip(macro.Actions[i].GetName(RecipeData!.ClassJob));
                         }
@@ -289,7 +289,7 @@ public sealed class MacroList : Window, IDisposable
                         {
                             var amtMore = itemCount - itemsPerRow * 2;
                             var pos = ImGui.GetCursorPos();
-                            ImGui.Image(macro.Actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(miniRowHeight), default, Vector2.One, new(1, 1, 1, .5f));
+                            ImGui.Image(macro.Actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(miniRowHeight), default, Vector2.One, new(1, 1, 1, .5f));
                             if (ImGui.IsItemHovered())
                                 ImGuiUtils.Tooltip($"{macro.Actions[i].GetName(RecipeData!.ClassJob)}\nand {amtMore} more");
                             ImGui.SetCursorPos(pos);

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -240,11 +240,11 @@ public sealed unsafe class RecipeNote : Window, IDisposable
         {
             var instance = CSRecipeNote.Instance();
 
-            var list = instance->RecipeList;
-            if (list == null)
+            if (instance == null)
                 return false;
 
-            var recipeEntry = list->SelectedRecipe;
+            var recipeEntry = instance->RecipeList->SelectedRecipe;
+
             if (recipeEntry == null)
                 return false;
 

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -533,7 +533,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             uv0 /= new Vector2(56);
             uv1 /= new Vector2(56);
 
-            ImGui.Image(Service.IconManager.GetIconCached(RecipeData.ClassJob.GetIconId()).ImGuiHandle, new Vector2(imageSize), uv0, uv1);
+            ImGui.Image(Service.IconManager.GetIconCached(RecipeData.ClassJob.GetIconId()).Handle, new Vector2(imageSize), uv0, uv1);
             ImGui.SameLine(0, 5);
 
             if (level != 0)
@@ -547,7 +547,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (hasSplendorous)
             {
                 ImGui.SameLine(0, 3);
-                ImGui.Image(SplendorousBadge.ImGuiHandle, new Vector2(imageSize));
+                ImGui.Image(SplendorousBadge.Handle, new Vector2(imageSize));
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"Splendorous Tool");
             }
@@ -555,7 +555,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (hasSpecialist)
             {
                 ImGui.SameLine(0, 3);
-                ImGui.Image(SpecialistBadge.ImGuiHandle, new Vector2(imageSize), Vector2.Zero, Vector2.One, new(0.99f, 0.97f, 0.62f, 1f));
+                ImGui.Image(SpecialistBadge.Handle, new Vector2(imageSize), Vector2.Zero, Vector2.One, new(0.99f, 0.97f, 0.62f, 1f));
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"Specialist");
             }
@@ -563,7 +563,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (shouldHaveManip)
             {
                 ImGui.SameLine(0, 3);
-                ImGui.Image(NoManipulationBadge.ImGuiHandle, new Vector2(imageSize));
+                ImGui.Image(NoManipulationBadge.Handle, new Vector2(imageSize));
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"No Manipulation (Missing Job Quest)");
             }
@@ -637,7 +637,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                     ImGuiUtils.TextCentered($"You are missing the required equipment.");
                     ImGuiUtils.AlignCentered(imageSize + 5 + ImGui.CalcTextSize(itemName).X);
                     ImGui.AlignTextToFramePadding();
-                    ImGui.Image(Service.IconManager.GetIconCached(item.Icon).ImGuiHandle, new(imageSize));
+                    ImGui.Image(Service.IconManager.GetIconCached(item.Icon).Handle, new(imageSize));
                     ImGui.SameLine(0, 5);
                     ImGui.TextUnformatted(itemName);
                 }
@@ -652,7 +652,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                     ImGuiUtils.TextCentered($"You are missing the required status effect.");
                     ImGuiUtils.AlignCentered(imageSize.X + 5 + ImGui.CalcTextSize(statusName).X);
                     ImGui.AlignTextToFramePadding();
-                    ImGui.Image(statusIcon.ImGuiHandle, imageSize);
+                    ImGui.Image(statusIcon.Handle, imageSize);
                     ImGui.SameLine(0, 5);
                     ImGui.TextUnformatted(statusName);
                 }
@@ -731,7 +731,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                 );
             ImGui.AlignTextToFramePadding();
 
-            ImGui.Image(Service.IconManager.GetIconCached(RecipeData.Recipe.ItemResult.Value!.Icon).ImGuiHandle, new Vector2(imageSize));
+            ImGui.Image(Service.IconManager.GetIconCached(RecipeData.Recipe.ItemResult.Value!.Icon).Handle, new Vector2(imageSize));
 
             ImGui.SameLine(0, 5);
             ImGui.TextUnformatted(textLevel);
@@ -748,7 +748,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (isAdjustable)
             {
                 ImGui.SameLine(0, 3);
-                ImGui.Image(CosmicExplorationBadge.ImGuiHandle, new(imageSize));
+                ImGui.Image(CosmicExplorationBadge.Handle, new(imageSize));
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"Cosmic Exploration");
             }
@@ -757,7 +757,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             {
                 ImGui.SameLine(0, 3);
                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() + badgeOffset);
-                ImGui.Image(CollectibleBadge.ImGuiHandle, badgeSize);
+                ImGui.Image(CollectibleBadge.Handle, badgeSize);
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"Collectible");
             }
@@ -766,7 +766,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             {
                 ImGui.SameLine(0, 3);
                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() + badgeOffset);
-                ImGui.Image(ExpertBadge.ImGuiHandle, badgeSize);
+                ImGui.Image(ExpertBadge.Handle, badgeSize);
                 if (ImGui.IsItemHovered())
                     ImGuiUtils.Tooltip($"Expert Recipe");
             }
@@ -1071,7 +1071,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                             var shouldShowMore = i + 1 == itemsPerRow * 2 && i + 1 < itemCount;
                             if (!shouldShowMore)
                             {
-                                ImGui.Image(actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(miniRowHeight));
+                                ImGui.Image(actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(miniRowHeight));
                                 if (ImGui.IsItemHovered())
                                     ImGuiUtils.Tooltip(actions[i].GetName(RecipeData!.ClassJob));
                             }
@@ -1079,7 +1079,7 @@ public sealed unsafe class RecipeNote : Window, IDisposable
                             {
                                 var amtMore = itemCount - itemsPerRow * 2;
                                 var pos = ImGui.GetCursorPos();
-                                ImGui.Image(actions[i].GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(miniRowHeight), default, Vector2.One, new(1, 1, 1, .5f));
+                                ImGui.Image(actions[i].GetIcon(RecipeData!.ClassJob).Handle, new(miniRowHeight), default, Vector2.One, new(1, 1, 1, .5f));
                                 if (ImGui.IsItemHovered())
                                     ImGuiUtils.Tooltip($"{actions[i].GetName(RecipeData!.ClassJob)}\nand {amtMore} more");
                                 ImGui.SetCursorPos(pos);

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -243,8 +243,12 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (instance == null)
                 return false;
 
-            var recipeEntry = instance->RecipeList->SelectedRecipe;
+            var list = instance->RecipeList;
 
+            if (list == null)
+                return false;
+
+            var recipeEntry = list->SelectedRecipe;
             if (recipeEntry == null)
                 return false;
 

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -20,7 +20,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -205,11 +205,9 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (Addon->WindowNode == null)
                 return false;
 
-            // Check if RecipeNote has a visible selected recipe
-            if (!Addon->GetNodeById(57)->IsVisible())
-                return false;
-
-            return true;
+            // Check if RecipeNote has a visible selected recipe and has returned a valid pointer 
+            var recipeDisplayNode = Addon->GetNodeById(57);
+            return recipeDisplayNode != null && recipeDisplayNode->IsVisible();
         }
 
         bool ShouldUseWKSRecipeNote()
@@ -226,11 +224,9 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             if (Addon->WindowNode == null)
                 return false;
 
-            // Check if WKS has a visible selected recipe
-            if (!Addon->GetNodeById(13)->IsVisible())
-                return false;
-
-            return true;
+            // Check if WKS has a visible selected recipe and has returned a valid pointer
+            var wksRecipeDisplayNode = Addon->GetNodeById(13);
+            return wksRecipeDisplayNode != null && wksRecipeDisplayNode->IsVisible();
         }
 
         if (ShouldUseRecipeNote())

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -1115,12 +1115,12 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             ImGui.TableNextColumn();
             ImGui.TextUnformatted("Current");
             ImGui.TableNextColumn();
-            ImGui.TextColored(new(0, 1, 0, 1), $"{current}");
+            ImGui.TextColored(new Vector4(0f, 1f, 0f, 1f), $"{current}");
 
             ImGui.TableNextColumn();
             ImGui.TextUnformatted("Required");
             ImGui.TableNextColumn();
-            ImGui.TextColored(new(1, 0, 0, 1), $"{required}");
+            ImGui.TextColored(new Vector4(1f, 0f, 0f, 1f), $"{required}");
 
             ImGui.TableNextColumn();
             ImGui.TextUnformatted("You need");

--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -194,9 +194,12 @@ public sealed unsafe class RecipeNote : Window, IDisposable
 
         bool ShouldUseRecipeNote()
         {
-            Addon = (AtkUnitBase*)Service.GameGui.GetAddonByName("RecipeNote");
-            if (Addon == null)
+            var recipeNotePtr = Service.GameGui.GetAddonByName("RecipeNote");
+
+            if (recipeNotePtr.IsNull)
                 return false;
+
+            Addon = (AtkUnitBase*)recipeNotePtr.Address;
 
             // Check if RecipeNote addon is visible
             if (Addon->WindowNode == null)
@@ -211,7 +214,11 @@ public sealed unsafe class RecipeNote : Window, IDisposable
 
         bool ShouldUseWKSRecipeNote()
         {
-            Addon = (AtkUnitBase*)Service.GameGui.GetAddonByName("WKSRecipeNotebook");
+            var wksNotePtr = Service.GameGui.GetAddonByName("WKSRecipeNotebook");
+            if (wksNotePtr.IsNull)
+                return false;
+
+            Addon = (AtkUnitBase*)wksNotePtr.Address;
             if (Addon == null)
                 return false;
 

--- a/Craftimizer/Windows/Settings.cs
+++ b/Craftimizer/Windows/Settings.cs
@@ -75,38 +75,37 @@ public sealed class Settings : Window, IDisposable
     }
 
     private static void DrawOption<T>(string label, string tooltip, T value, T min, T max, Action<T> setter, ref bool isDirty) where T : struct, INumber<T>
-{
-    ImGui.SetNextItemWidth(OptionWidth);
-
-    System.Text.Encoding.UTF8.GetBytes(value.ToString() + "\0", TextBuffer);
-
-    if (ImGui.InputText(label, TextBuffer, ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CharsDecimal))
     {
-        var newText = System.Text.Encoding.UTF8.GetString(TextBuffer, 0, Array.IndexOf(TextBuffer, (byte)'\0'));
+        ImGui.SetNextItemWidth(OptionWidth);
 
-        if (T.TryParse(newText, null, out var newValue))
+        System.Text.Encoding.UTF8.GetBytes(value.ToString() + "\0", TextBuffer);
+
+        if (ImGui.InputText(label, TextBuffer, ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.CharsDecimal))
         {
-            newValue = T.Clamp(newValue, min, max);
+            var newText = System.Text.Encoding.UTF8.GetString(TextBuffer, 0, Array.IndexOf(TextBuffer, (byte)'\0'));
+
+            if (T.TryParse(newText, null, out var newValue))
+            {
+                newValue = T.Clamp(newValue, min, max);
+                if (value != newValue)
+                {
+                    setter(newValue);
+                    isDirty = true;
+                }
+            }
+        }
+        else
+        {
+            var newValue = T.Clamp(value, min, max);
             if (value != newValue)
             {
                 setter(newValue);
                 isDirty = true;
             }
         }
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGuiUtils.TooltipWrapped(tooltip);
     }
-    else
-    {
-        var newValue = T.Clamp(value, min, max);
-        if (value != newValue)
-        {
-            setter(newValue);
-            isDirty = true;
-        }
-    }
-
-    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-        ImGuiUtils.TooltipWrapped(tooltip);
-}
 
     private static void DrawOption(string label, string tooltip, string value, Action<string> setter, ref bool isDirty)
     {

--- a/Craftimizer/Windows/Settings.cs
+++ b/Craftimizer/Windows/Settings.cs
@@ -8,7 +8,7 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using FFXIVClientStructs.FFXIV.Client.UI;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Craftimizer/Windows/Settings.cs
+++ b/Craftimizer/Windows/Settings.cs
@@ -834,7 +834,7 @@ public sealed class Settings : Window, IDisposable
                         iconTint = new(1, 1f, .5f, 1);
                     else if (isRisky)
                         iconTint = new(1, .5f, .5f, 1);
-                    if (ImGui.ImageButton(actions[i].GetIcon(recipeData.ClassJob).ImGuiHandle, new(imageSize), default, Vector2.One, 0, default, iconTint))
+                    if (ImGui.ImageButton(actions[i].GetIcon(recipeData.ClassJob).Handle, new(imageSize), default, Vector2.One, 0, default, iconTint))
                     {
                         isDirty = true;
                         if (isEnabled)
@@ -1104,7 +1104,7 @@ public sealed class Settings : Window, IDisposable
                 ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, iconDim.X);
 
                 ImGui.TableNextColumn();
-                ImGui.Image(icon.ImGuiHandle, iconDim);
+                ImGui.Image(icon.Handle, iconDim);
 
                 ImGui.TableNextColumn();
                 ImGuiUtils.AlignMiddle(new(float.PositiveInfinity, HeaderFont.GetFontSize() + SubheaderFont.GetFontSize() + ImGui.GetFontSize() * 3 + ImGui.GetStyle().ItemSpacing.Y * 4), new(0, iconDim.Y));

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -168,7 +168,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
             return false;
         }
 
-        Addon = (AddonSynthesis*)Service.GameGui.GetAddonByName("Synthesis");
+        Addon = (AddonSynthesis*)Service.GameGui.GetAddonByName("Synthesis").Address;
 
         if (Addon == null)
         {
@@ -331,7 +331,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
                 
                 isPressed = ImGuiExtras.ButtonBehavior(bb, id, out isHovered, out isHeld, ImGuiButtonFlags.None);
             }
-            ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).ImGuiHandle, new(imageSize), default, Vector2.One, 0, default, failedAction ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One);
+            ImGui.ImageButton(action.GetIcon(RecipeData!.ClassJob).Handle, new(imageSize), default, Vector2.One, 0, default, failedAction ? new(1, 1, 1, ImGui.GetStyle().DisabledAlpha) : Vector4.One);
             if (isPressed && i == 0)
             {
                 if (ExecuteNextAction())
@@ -380,7 +380,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
                     var icon = effect.GetIcon(effects.GetStrength(effect));
                     var size = new Vector2(iconHeight * (icon.AspectRatio ?? 1), iconHeight);
 
-                    ImGui.Image(icon.ImGuiHandle, size);
+                    ImGui.Image(icon.Handle, size);
                     if (!effect.IsIndefinite())
                     {
                         ImGui.SetCursorPosY(ImGui.GetCursorPosY() - durationShift);

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -210,7 +210,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
 
         Macro.FlushQueue();
 
-        var isInCraftAction = Service.Condition[ConditionFlag.Crafting40];
+        var isInCraftAction = Service.Condition[ConditionFlag.ExecutingCraftingAction];
         if (!isInCraftAction && wasInCraftAction)
             RefreshCurrentState();
         wasInCraftAction = isInCraftAction;
@@ -289,7 +289,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
     {
         var spacing = ImGui.GetStyle().ItemSpacing.X;
         var imageSize = ImGui.GetFrameHeight() * 2;
-        var canExecute = !Service.Condition[ConditionFlag.Crafting40];
+        var canExecute = !Service.Condition[ConditionFlag.ExecutingCraftingAction];
         var lastState = Macro.InitialState;
         hoveredState = null;
 
@@ -476,7 +476,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
 
     public bool ExecuteNextAction()
     {
-        var canExecute = !Service.Condition[ConditionFlag.Crafting40];
+        var canExecute = !Service.Condition[ConditionFlag.ExecutingCraftingAction];
         var action = NextAction;
         if (canExecute && action != null)
         {

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -15,7 +15,7 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Shell;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -528,9 +528,13 @@ public sealed unsafe class SynthHelper : Window, IDisposable
 
     private void OnUseAction(ActionType action)
     {
-        Addon = (AddonSynthesis*)Service.GameGui.GetAddonByName("Synthesis");
-        if (Addon == null)
+        var addonPtr = Service.GameGui.GetAddonByName("Synthesis");
+
+        if (addonPtr.IsNull)
             return;
+
+        Addon = (AddonSynthesis*)addonPtr.Address;
+        
         if (Addon->AtkUnitBase.WindowNode == null)
             return;
 

--- a/Craftimizer/packages.lock.json
+++ b/Craftimizer/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "J5TJLV3f16T/E2H2P17ClWjtfEBPpq3yxvqW46eN36JCm6wR+EaoaYkqG9Rm5sHqs3/nK/vKjWWyvEs/jhKoXw=="
+        "requested": "[13.0.0, )",
+        "resolved": "13.0.0",
+        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Hello. I think I've succesfully updated Craftimizer to API13. I ran it and crafted a few things, opened a few menus, and it seems to be working alright. I'm unable to test it thoroughly. Perhaps offering my fork as a test version through Dalamud's testing feature could work to this end.

Summary of changes:
- Updated the project to Dalamud API13.
- Fixed all breaking changes related to ImGui. Biggest one was migrating from ref string to the byte[] buffer pattern for all InputText calls.
-  Updated all ImGui/ImPlot calls to use the new API (e.g., ImTextureID, wrapper types, callbacks).
- Corrected all outdated Lumina sheet properties (e.g., Recipe.Unknown0 is now Recipe.MaxAdjustableJobLevel.RowId)
- Resolved various other compile errors related to pointer/handle access and delegate signature changes.
Testing performed:
- The plugin loads in-game without any errors in the Dalamud console (waow)
- I've crafted a few things using the UI.
- I've opened the main windows and interacted with them (macro editor, settings panels)
- Recipe data seems to load correctly.