### PR TITLE
Reload recipe data on job level change

### DIFF
--- a/Craftimizer/Windows/RecipeNote.cs
+++ b/Craftimizer/Windows/RecipeNote.cs
@@ -267,6 +267,11 @@ public sealed unsafe class RecipeNote : Window, IDisposable
             var characterStats = Gearsets.CalculateCharacterStats(gearStats, gearItems, RecipeData.ClassJob.GetPlayerLevel(), RecipeData.ClassJob.CanPlayerUseManipulation());
             if (characterStats != CharacterStats)
             {
+                // Re-initialize recipe data to recalculate adjusted level if needed
+                if (RecipeData.AdjustedJobLevel != null && characterStats.Level != CharacterStats?.Level)
+                {
+                    RecipeData = new(RecipeData.RecipeId);
+                }
                 CharacterStats = characterStats;
                 StatsChanged = true;
             }


### PR DESCRIPTION
This fixes recipes that adjust to the job level (i.e., Cosmic Exploration) not being set to the right level after a level up when the recipe doesn't change. This happens frequently during Red Alerts.

This can be considered an extended fix for #43.

I tested this myself on 3 different jobs, so I'm fairly confident it fixes the problem.