### PR TITLE
Added new option to automatically collapse the Synth Helper window

### DIFF
--- a/Craftimizer/Configuration.cs
+++ b/Craftimizer/Configuration.cs
@@ -203,6 +203,7 @@ public partial class Configuration
     public ProgressBarType ProgressType { get; set; } = ProgressBarType.Colorful;
 
     public bool PinSynthHelperToWindow { get; set; } = true;
+    public bool CollapseSynthHelper { get; set; }
     public bool PinRecipeNoteToWindow { get; set; } = true;
 
     public MacroCopyConfiguration MacroCopy { get; set; } = new();

--- a/Craftimizer/Windows/Settings.cs
+++ b/Craftimizer/Windows/Settings.cs
@@ -921,6 +921,15 @@ public sealed class Settings : Window, IDisposable
         );
 
         DrawOption(
+            "Always Collapse Helper Window",
+            "Enabling this will cause the Helper Window to be collapsed whenever you start " +
+            "a new craft, preventing the solver from running automatically.",
+            Config.CollapseSynthHelper,
+            v => Config.CollapseSynthHelper = v,
+            ref isDirty
+        );
+
+        DrawOption(
             "Automatically Suggest Macro",
             "(Can cause frame drops!) When navigating to a new recipe or changing your gear " +
             "stats, automatically suggest a new macro (equivalent to clicking \"Generate\" " +

--- a/Craftimizer/Windows/SynthHelper.cs
+++ b/Craftimizer/Windows/SynthHelper.cs
@@ -112,6 +112,11 @@ public sealed unsafe class SynthHelper : Window, IDisposable
     private bool WasOpen { get; set; }
     private bool WasCollapsed { get; set; }
 
+    /// <summary>
+    /// Used to automatically collapse the helper window when a new craft starts.
+    /// </summary>
+    private bool ShouldCollapse { get; set; }
+
     private bool ShouldCalculate => !IsCollapsed && ShouldOpen;
     private bool WasCalculatable { get; set; }
 
@@ -203,6 +208,8 @@ public sealed unsafe class SynthHelper : Window, IDisposable
         {
             OnStartCrafting(recipeId);
             OnStateUpdated();
+
+            if (Service.Configuration.CollapseSynthHelper) ShouldCollapse = true;
         }
 
         if (IsRecalculateQueued)
@@ -266,6 +273,13 @@ public sealed unsafe class SynthHelper : Window, IDisposable
 
     public override void Draw()
     {
+
+        if (ShouldCollapse)
+        {
+            ImGui.SetWindowCollapsed(true);
+            ShouldCollapse = false;
+        }
+
         IsCollapsed = false;
 
         DrawMacro();
@@ -285,6 +299,7 @@ public sealed unsafe class SynthHelper : Window, IDisposable
 
     private SimulationState? hoveredState;
     private SimulationState DisplayedState => hoveredState ?? (Service.Configuration.SynthHelperDisplayOnlyFirstStep ? Macro.FirstState : Macro.State);
+
     private void DrawMacro()
     {
         var spacing = ImGui.GetStyle().ItemSpacing.X;


### PR DESCRIPTION
Can be used to stop the solver from running automatically whenever you start a new craft. Found myself wanting this as I lag when the solver starts, which is a (minor) annoyance when I'm just running macros. Thank you contributors for all your work.