### PR TITLE
Support Robust condition from 7.41

### DIFF
--- a/Craftimizer/SimulatorUtils.cs
+++ b/Craftimizer/SimulatorUtils.cs
@@ -219,6 +219,7 @@ internal static class ConditionUtils
             Condition.Malleable => (13455, 14208),
             Condition.Primed => (13454, 14207),
             Condition.GoodOmen => (14214, 14215),
+            Condition.Robust => (14218, 14219),
             _ => (226, 14200) // Unknown
         };
 

--- a/Simulator/Condition.cs
+++ b/Simulator/Condition.cs
@@ -13,6 +13,7 @@ public enum Condition : byte
     Malleable,
     Primed,
     GoodOmen,
+    Robust,
 }
 
 public static class ConditionUtils
@@ -31,6 +32,7 @@ public static class ConditionUtils
         Malleable = 1 << 7, // 0x0080
         Primed    = 1 << 8, // 0x0100
         GoodOmen  = 1 << 9, // 0x0200
+        Robust    = 1 << 10, // 0x0400
     }
 
     public static Condition[] GetPossibleConditions(ushort conditionsFlag) =>

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -144,6 +144,7 @@ public class Simulator
             Condition.Malleable => 0.13f,
             Condition.Primed => 0.15f,
             Condition.GoodOmen => 0.12f, // https://github.com/ffxiv-teamcraft/simulator/issues/77
+            Condition.Robust => 0.10f, // https://github.com/ffxiv-teamcraft/simulator/commit/4b2949f935450d54324cba84f9214fcb945ecbcb
             _ => 0.00f
         };
 
@@ -166,6 +167,7 @@ public class Simulator
             Condition.Good => Condition.Normal,
             Condition.Excellent => Condition.Poor,
             Condition.GoodOmen => Condition.Good,
+            Condition.Robust => Condition.Sturdy,
             _ => GetNextRandomCondition()
         };
     }
@@ -214,7 +216,7 @@ public class Simulator
         var amt = (double)amount;
         if (HasEffect(EffectType.WasteNot) || HasEffect(EffectType.WasteNot2))
             amt /= 2;
-        if (Condition == Condition.Sturdy)
+        if (Condition == Condition.Sturdy || Condition == Condition.Robust)
             amt /= 2;
         return (int)Math.Ceiling(amt);
     }


### PR DESCRIPTION
Adds support for the new Robust condition added in Cosmic Exploration recipes in 7.41

<img width="349" height="139" alt="image" src="https://github.com/user-attachments/assets/9bbe685e-fe2e-46e1-a524-6b3b739ce3fc" />

It's basically Good Omen, except for Sturdy, and it _also_ provides the same effect as Sturdy itself. I've tested and it seems to work. Note, one thing I haven't implemented is the `GetColor` and `AddRGB` stuff as I don't really understand what that's doing or how to determine the numbers for it...