### PR TITLE
Update for 7.5 - Update ImRaii usage to new ref struct pattern

### DIFF
--- a/Benchmark/Craftimizer.Benchmark.csproj
+++ b/Benchmark/Craftimizer.Benchmark.csproj
@@ -20,11 +20,11 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.15.8" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ObjectLayoutInspector" Version="0.1.4" />
+    <PackageReference Include="ObjectLayoutInspector" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Craftimizer/Craftimizer.csproj
+++ b/Craftimizer/Craftimizer.csproj
@@ -33,12 +33,17 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <ProjectReference Include="..\Simulator\Craftimizer.Simulator.csproj" />
     <ProjectReference Include="..\Solver\Craftimizer.Solver.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="DalamudPackager" Version="15.0.0" />
+    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Craftimizer/Craftimizer.csproj
+++ b/Craftimizer/Craftimizer.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
   <PropertyGroup>
     <Authors>Asriel Camora</Authors>
     <Version>2.10.0.0</Version>
@@ -39,11 +39,6 @@
     </PackageReference>
     <ProjectReference Include="..\Simulator\Craftimizer.Simulator.csproj" />
     <ProjectReference Include="..\Solver\Craftimizer.Solver.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="DalamudPackager" Version="15.0.0" />
-    <PackageReference Update="DotNet.ReproducibleBuilds" Version="2.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Craftimizer/Craftimizer.csproj
+++ b/Craftimizer/Craftimizer.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/14.0.1">
   <PropertyGroup>
     <Authors>Asriel Camora</Authors>
-    <Version>2.9.1.1</Version>
+    <Version>2.10.0.0</Version>
     <PackageProjectUrl>https://github.com/WorkingRobot/Craftimizer.git</PackageProjectUrl>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/Craftimizer/ImRaii2.cs
+++ b/Craftimizer/ImRaii2.cs
@@ -8,78 +8,116 @@ namespace Craftimizer.Plugin;
 
 public static class ImRaii2
 {
-    private struct EndUnconditionally(Action endAction, bool success) : ImRaii.IEndObject, IDisposable
+    // Custom ref structs for each UI element. 
+    // This eliminates the need for allocating 'Action' delegates and boxing.
+
+    public ref struct GroupPanelDisposable
     {
-        private Action EndAction { get; } = endAction;
-
-        public bool Success { get; } = success;
-
-        public bool Disposed { get; private set; } = false;
+        private bool Disposed;
 
         public void Dispose()
         {
-            if (!Disposed)
-            {
-                EndAction();
-                Disposed = true;
-            }
+            if (Disposed) return;
+            ImGuiUtils.EndGroupPanel();
+            Disposed = true;
         }
+
+        public static implicit operator bool(GroupPanelDisposable _) => true;
     }
 
-    private struct EndConditionally(Action endAction, bool success) : ImRaii.IEndObject, IDisposable
-    {
-        public bool Success { get; } = success;
-
-        public bool Disposed { get; private set; } = false;
-
-        private Action EndAction { get; } = endAction;
-
-        public void Dispose()
-        {
-            if (!Disposed)
-            {
-                if (Success)
-                {
-                    EndAction();
-                }
-
-                Disposed = true;
-            }
-        }
-    }
-
-    public static ImRaii.IEndObject GroupPanel(string name, float width, out float internalWidth)
+    public static GroupPanelDisposable GroupPanel(string name, float width, out float internalWidth)
     {
         internalWidth = ImGuiUtils.BeginGroupPanel(name, width);
-        return new EndUnconditionally(ImGuiUtils.EndGroupPanel, true);
+        return new GroupPanelDisposable();
     }
 
-    public static ImRaii.IEndObject Plot(string title_id, Vector2 size, ImPlotFlags flags)
+    public ref struct PlotDisposable
     {
-        return new EndConditionally(new Action(ImPlot.EndPlot), ImPlot.BeginPlot(title_id, size, flags));
+        public bool Success { get; }
+        private bool Disposed;
+
+        public PlotDisposable(bool success)
+        {
+            Success = success;
+            Disposed = false;
+        }
+
+        public void Dispose()
+        {
+            if (Disposed) return;
+            if (Success)
+            {
+                ImPlot.EndPlot();
+            }
+            Disposed = true;
+        }
+
+        // Allows you to do: using var plot = ImRaii2.Plot(...); if (plot) { ... }
+        public static implicit operator bool(PlotDisposable d) => d.Success;
     }
 
-    public static ImRaii.IEndObject PushStyle(ImPlotStyleVar idx, Vector2 val)
+    public static PlotDisposable Plot(string title_id, Vector2 size, ImPlotFlags flags)
+    {
+        return new PlotDisposable(ImPlot.BeginPlot(title_id, size, flags));
+    }
+
+    public ref struct ImPlotStyleDisposable
+    {
+        private bool Disposed;
+
+        public void Dispose()
+        {
+            if (Disposed) return;
+            ImPlot.PopStyleVar();
+            Disposed = true;
+        }
+    }
+
+    public static ImPlotStyleDisposable PushStyle(ImPlotStyleVar idx, Vector2 val)
     {
         ImPlot.PushStyleVar(idx, val);
-        return new EndUnconditionally(ImPlot.PopStyleVar, true);
+        return new ImPlotStyleDisposable();
     }
 
-    public static ImRaii.IEndObject PushStyle(ImPlotStyleVar idx, float val)
+    public static ImPlotStyleDisposable PushStyle(ImPlotStyleVar idx, float val)
     {
         ImPlot.PushStyleVar(idx, val);
-        return new EndUnconditionally(ImPlot.PopStyleVar, true);
+        return new ImPlotStyleDisposable();
     }
 
-    public static ImRaii.IEndObject PushColor(ImPlotCol idx, Vector4 col)
+    public ref struct ImPlotColorDisposable
+    {
+        private bool Disposed;
+
+        public void Dispose()
+        {
+            if (Disposed) return;
+            ImPlot.PopStyleColor();
+            Disposed = true;
+        }
+    }
+
+    public static ImPlotColorDisposable PushColor(ImPlotCol idx, Vector4 col)
     {
         ImPlot.PushStyleColor(idx, col);
-        return new EndUnconditionally(ImPlot.PopStyleColor, true);
+        return new ImPlotColorDisposable();
     }
 
-    public static ImRaii.IEndObject TextWrapPos(float wrap_local_pos_x)
+    public ref struct TextWrapPosDisposable
+    {
+        private bool Disposed;
+
+        public void Dispose()
+        {
+            if (Disposed) return;
+            ImGui.PopTextWrapPos();
+            Disposed = true;
+        }
+    }
+
+    public static TextWrapPosDisposable TextWrapPos(float wrap_local_pos_x)
     {
         ImGui.PushTextWrapPos(wrap_local_pos_x);
-        return new EndUnconditionally(ImGui.PopTextWrapPos, true);
+        return new TextWrapPosDisposable();
     }
 }

--- a/Craftimizer/Utils/DynamicBars.cs
+++ b/Craftimizer/Utils/DynamicBars.cs
@@ -45,7 +45,7 @@ internal static class DynamicBars
                 defaultSize);
         });
 
-    private static ImRaii.Color? PushCollectableColor(this in BarData bar, float collectability, bool colorUnmetThreshold = true)
+    private static ImRaii.ColorDisposable? PushCollectableColor(this in BarData bar, float collectability, bool colorUnmetThreshold = true)
     {
         if (bar.Collectability is not { } collectabilities)
             return null;

--- a/Craftimizer/Utils/SynthesisValues.cs
+++ b/Craftimizer/Utils/SynthesisValues.cs
@@ -4,7 +4,7 @@ using Dalamud.Memory;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using System;
-using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.ValueType;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 
 namespace Craftimizer.Utils;
 

--- a/Craftimizer/Windows/Settings.cs
+++ b/Craftimizer/Windows/Settings.cs
@@ -50,14 +50,14 @@ public sealed class Settings : Window, IDisposable
         SelectedTab = label;
     }
 
-    private ImRaii.IEndObject TabItem(string label)
+    private ImRaii.TabItemDisposable TabItem(string label)
     {
         var isSelected = string.Equals(SelectedTab, label, StringComparison.Ordinal);
         if (isSelected)
         {
             SelectedTab = null;
-            var open = true;
-            return ImRaii.TabItem(label, ref open, ImGuiTabItemFlags.SetSelected);
+            // Use the overload that takes flags directly without the 'ref bool'
+            return ImRaii.TabItem(label, ImGuiTabItemFlags.SetSelected);
         }
         return ImRaii.TabItem(label);
     }
@@ -122,9 +122,10 @@ public sealed class Settings : Window, IDisposable
     private static void DrawOption<T>(string label, string tooltip, Func<T, string> getName, Func<T, string> getTooltip, T value, Action<T> setter, ref bool isDirty, params T[] excludedValues) where T : struct, Enum
     {
         ImGui.SetNextItemWidth(OptionWidth);
+        // ImRaii.Combo returns a ComboDisposable ref struct
         using (var combo = ImRaii.Combo(label, getName(value)))
         {
-            if (combo)
+            if (combo) // Uses the implicit bool operator
             {
                 foreach (var type in Enum.GetValues<T>())
                 {

--- a/Craftimizer/packages.lock.json
+++ b/Craftimizer/packages.lock.json
@@ -4,15 +4,15 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[1.2.39, )",
-        "resolved": "1.2.39",
-        "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
       },
       "MathNet.Numerics": {
         "type": "Direct",
@@ -22,16 +22,16 @@
       },
       "Meziantou.Analyzer": {
         "type": "Direct",
-        "requested": "[2.0.264, )",
-        "resolved": "2.0.264",
-        "contentHash": "zRG13RDG446rZNdd/YjKRd4utpbjleRDUqNQSrX0etMnH8Rz9NBlXUpS5aR2ExoOokhNfkdOW8HpLzjLj5x0hQ=="
+        "requested": "[3.0.61, )",
+        "resolved": "3.0.61",
+        "contentHash": "Ed/5bKmY38QbQJgL9wmWnweX4mq3WaNYNq8kp4Hk/WPIFuLuK/P/dEB/ZnenQius+NNDXxTIiCXFPmQdLrHWMg=="
       },
       "DotNext": {
         "type": "Transitive",
-        "resolved": "5.26.1",
-        "contentHash": "rcy6Yrpb64B7qYm/+D+4sfBUzwX/IOGeJBYReDL8/TAIp8aZrZPtXx8nwkYjWCuakYn2tBppwefIM6pd/cOnMw==",
+        "resolved": "6.1.0",
+        "contentHash": "oUvq/a1Fydh1dC2QtGp+opiG9XjzJNRctigtC60+PlKiqdVr3TOgkBIYy/U/Q3PfzmLudpsI2i1OdVSho9wbSQ==",
         "dependencies": {
-          "System.IO.Hashing": "8.0.0"
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "Raphael.Net": {
@@ -41,8 +41,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
       "craftimizer.simulator": {
         "type": "Project"
@@ -51,7 +51,7 @@
         "type": "Project",
         "dependencies": {
           "Craftimizer.Simulator": "[1.0.0, )",
-          "DotNext": "[5.26.1, )",
+          "DotNext": "[6.1.0, )",
           "Raphael.Net": "[4.1.0, )"
         }
       }

--- a/Simulator/Craftimizer.Simulator.csproj
+++ b/Simulator/Craftimizer.Simulator.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solver/Craftimizer.Solver.csproj
+++ b/Solver/Craftimizer.Solver.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="5.26.1" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.264">
+    <PackageReference Include="DotNext" Version="6.1.0" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Test/Craftimizer.Test.csproj
+++ b/Test/Craftimizer.Test.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.199">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the plugin to support the recent changes in Dalamud's ImRaii library.
-Removed IEndObject (obsolete/removed).
-Converted custom GroupPanel and ImPlot wrappers to ref structs to prevent boxing and memory allocations.
-Fixed TabItem usage to comply with C# ref-safety rules.
Tested in-game and settings/tabs/panels are functioning correctly.